### PR TITLE
Update _buildBlock()

### DIFF
--- a/webVersion.js
+++ b/webVersion.js
@@ -266,7 +266,7 @@ class CodeLine {
             args: {
                 items: [
                     ...args.map((item, i) => {
-                        if (typeof item != 'number' && typeof item != 'string') return item.setSlot(i);
+                        if (typeof item != 'number' && typeof item != 'string') return Object.assign({}, item.setSlot(i)); // Creates a shallow copy of the item with the new slot
                         return new Item({
                             id: typeof item == 'number' ? 'num' : 'txt',
                             name: item.toString(),


### PR DESCRIPTION
_buildBlock now stores shallow copies of items so that if the slot gets changed for a variable, it won't get changed in every block the variable is in, for example. This fixes the bug I reported on discord. I haven't tested if this works, but it should. So I would test it yourself before officially accepting it.